### PR TITLE
net: core: fix Null ptr dereference in UID-based routing

### DIFF
--- a/include/net/route.h
+++ b/include/net/route.h
@@ -143,7 +143,7 @@ static inline struct rtable *ip_route_output_ports(struct net *net, struct flowi
 	flowi4_init_output(fl4, oif, sk ? sk->sk_mark : 0, tos,
 			   RT_SCOPE_UNIVERSE, proto,
 			   sk ? inet_sk_flowi_flags(sk) : 0,
-			   daddr, saddr, dport, sport, sock_i_uid(sk));
+			   daddr, saddr, dport, sport, sk ? sock_i_uid(sk) : GLOBAL_ROOT_UID);
 	if (sk)
 		security_sk_classify_flow(sk, flowi4_to_flowi(fl4));
 	return ip_route_output_flow(net, fl4, sk);

--- a/net/ipv4/route.c
+++ b/net/ipv4/route.c
@@ -531,7 +531,8 @@ static void __build_flow_key(struct flowi4 *fl4, struct sock *sk,
 	flowi4_init_output(fl4, oif, mark, tos,
 			   RT_SCOPE_UNIVERSE, prot,
 			   flow_flags,
-			   iph->daddr, iph->saddr, 0, 0, sock_i_uid(sk));
+			   iph->daddr, iph->saddr, 0, 0,
+			   sk ? sock_i_uid(sk) : GLOBAL_ROOT_UID);
 }
 
 static void build_skb_flow_key(struct flowi4 *fl4, const struct sk_buff *skb,


### PR DESCRIPTION
This should fix the kernel panic after opening certain apps like Youtube or navigating to Settings > Connected devices > Connection preferences.